### PR TITLE
Add JS/TS code folding support to language server

### DIFF
--- a/packages/core/__tests__/language-server/folding-ranges.test.ts
+++ b/packages/core/__tests__/language-server/folding-ranges.test.ts
@@ -1,0 +1,238 @@
+import { Project } from 'glint-monorepo-test-utils';
+import { describe, beforeEach, afterEach, test, expect } from 'vitest';
+import { stripIndent } from 'common-tags';
+
+describe('Language Server: Folding Ranges', () => {
+  let project!: Project;
+
+  beforeEach(async () => {
+    project = await Project.create();
+  });
+
+  afterEach(async () => {
+    await project.destroy();
+  });
+
+  test('function', () => {
+    project.write({
+      'example.ts': stripIndent`
+        function foo() {
+          return 'bar';
+        }
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 0,
+        endLine: 1,
+        kind: undefined,
+      },
+    ]);
+  });
+
+  test('nested function', () => {
+    project.write({
+      'example.ts': stripIndent`
+        function topLevel() {
+
+          function nested() {
+            return 'bar';
+          }
+
+          return nested();
+        }
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 0,
+        endLine: 6,
+        kind: undefined,
+      },
+      {
+        startLine: 2,
+        endLine: 3,
+        kind: undefined,
+      },
+    ]);
+  });
+
+  test('imports', () => {
+    project.write({
+      'example.ts': stripIndent`
+        import Component, { hbs } from '@glimmerx/component';
+        import foo from 'bar';
+        import { baz } from 'qux';
+
+        export default { foo, baz, Component };
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 0,
+        endLine: 2,
+        kind: 'imports',
+      },
+    ]);
+  });
+
+  test('comments', () => {
+    project.write({
+      'example.ts': stripIndent`
+        // This is
+        // a
+        // multiline
+        // comment
+
+        const foo = 'bar';
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 0,
+        endLine: 3,
+        kind: 'comment',
+      },
+    ]);
+  });
+
+  test('region', () => {
+    project.write({
+      'example.ts': stripIndent`
+        const foo = 'bar';
+
+        // #region
+
+        const bar = 'baz';
+
+        // #endregion
+
+        export default { foo, bar };
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 2,
+        endLine: 6,
+        kind: 'region',
+      },
+    ]);
+  });
+
+  test('simple component', () => {
+    project.write({
+      'example.ts': stripIndent`
+        import Component, { hbs } from '@glimmerx/component';
+        import { tracked } from '@glimmer/tracking';
+
+        export interface EmberComponentArgs {
+          message: string;
+        }
+
+        export interface EmberComponentSignature {
+          Element: HTMLDivElement;
+          Args: EmberComponentArgs;
+        }
+
+        /**
+         * A simple component that renders a message.
+         */
+        export default class Greeting extends Component<EmberComponentSignature> {
+          @tracked message = this.args.message;
+
+          get capitalizedMessage() {
+            return this.message.toUpperCase();
+          }
+        }
+
+        declare module '@glint/environment-ember-loose/registry' {
+          export default interface Registry {
+            EmberComponent: typeof EmberComponent;
+            'ember-component': typeof EmberComponent;
+          }
+        }
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      // Imports
+      {
+        startLine: 0,
+        endLine: 1,
+        kind: 'imports',
+      },
+
+      // EmberComponentArgs
+      {
+        startLine: 3,
+        endLine: 4,
+        kind: undefined,
+      },
+
+      // EmberComponentSignature
+      {
+        startLine: 7,
+        endLine: 9,
+        kind: undefined,
+      },
+
+      // Code Comment
+      {
+        startLine: 12,
+        endLine: 14,
+        kind: 'comment',
+      },
+
+      // Greeting Component
+      {
+        startLine: 15,
+        endLine: 20,
+        kind: undefined,
+      },
+
+      // capitalizedMessage
+      {
+        startLine: 18,
+        endLine: 19,
+        kind: undefined,
+      },
+
+      // declare module
+      {
+        startLine: 23,
+        endLine: 27,
+        kind: undefined,
+      },
+
+      // interface Registry
+      {
+        startLine: 24,
+        endLine: 26,
+        kind: undefined,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -29,6 +29,7 @@ export const capabilities: ServerCapabilities = {
   codeActionProvider: {
     codeActionKinds: [CodeActionKind.QuickFix],
   },
+  foldingRangeProvider: true,
   definitionProvider: true,
   workspaceSymbolProvider: true,
   renameProvider: {
@@ -233,5 +234,11 @@ export function bindLanguageServerPool({
 
       scheduleDiagnostics();
     });
+  });
+
+  connection.onFoldingRanges((params) => {
+    return pool.withServerForURI(params.textDocument.uri, ({ server }) =>
+      server.getFoldingRanges(params.textDocument.uri)
+    );
   });
 }

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -420,48 +420,56 @@ export default class GlintLanguageServer {
 
   public getFoldingRanges(uri: string): FoldingRange[] {
     const filePath = uriToFilePath(uri);
-    const documentContents = this.documents.getDocumentContents(filePath);
-    const spans = this.service.getOutliningSpans(filePath);
 
-    let foldingRanges = [];
+    let foldingRanges: FoldingRange[] = [];
+    this.service.getOutliningSpans(filePath).forEach((outliningSpan, index) => {
+      const foldingRange = this.outliningSpanToFoldingRange(outliningSpan, filePath);
 
-    for (const span of spans) {
-      const foldingRange = this.asFoldingRange(span, documentContents);
-      if (foldingRange) {
-        foldingRanges.push(foldingRange);
+      if (
+        !foldingRange ||
+        (index > 0 && foldingRange.startLine === 0) ||
+        foldingRange.startLine === foldingRange.endLine
+      ) {
+        return;
       }
-    }
+
+      foldingRanges.push(foldingRange);
+    });
 
     return foldingRanges;
   }
 
-  private asFoldingRange(span: ts.OutliningSpan, fileContents: string): FoldingRange {
-    const start = offsetToPosition(fileContents, span.textSpan.start);
-    const end = offsetToPosition(fileContents, span.textSpan.start + span.textSpan.length);
-    const kind = this.asFoldingRangeKind(span);
+  private outliningSpanToFoldingRange(
+    span: ts.OutliningSpan,
+    fileName: string
+  ): FoldingRange | undefined {
+    // The OutliningSpan.textSpan's length is inclusive. This is a
+    // workaround for off-by-one & out-of-range errors caused by this.
+    span.textSpan.length = span.textSpan.length - 1;
+    const location = this.textSpanToLocation(fileName, span.textSpan);
 
-    // TODO: Implement this before opening a PR
-    // // workaround for https://github.com/Microsoft/vscode/issues/49904
-    // if (span.kind === 'comment') {
-    //   const line = document.getLine(range.start.line);
-    //   if (line.match(/\/\/\s*#endregion/gi)) {
-    //     return undefined;
-    //   }
-    // }
+    if (!location) {
+      return;
+    }
+
+    const { start, end } = location.range;
 
     // workaround for https://github.com/Microsoft/vscode/issues/47240
-    let lastCharOfSpan = fileContents[span.textSpan.start + span.textSpan.length - 1];
-    const endLine = lastCharOfSpan === '}' ? Math.max(end.line - 1, start.line) : end.line;
+    const originalContents = this.documents.getDocumentContents(fileName);
+    const originalEnd = positionToOffset(originalContents, end);
+    const lastCharOfSpan = originalContents[originalEnd];
 
     return {
       startLine: start.line,
-      endLine,
-      kind,
+      endLine: lastCharOfSpan === '}' ? Math.max(end.line - 1, start.line) : end.line,
+      kind: this.outliningSpanKindToFoldingRangeKind(span),
     };
   }
 
-  private asFoldingRangeKind(span: ts.OutliningSpan): FoldingRangeKind | undefined {
-    switch (span.kind) {
+  private outliningSpanKindToFoldingRangeKind(
+    outliningSpan: ts.OutliningSpan
+  ): FoldingRangeKind | undefined {
+    switch (outliningSpan.kind) {
       case 'comment':
         return FoldingRangeKind.Comment;
       case 'region':

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -21,6 +21,8 @@ import {
   TextDocumentEdit,
   OptionalVersionedTextDocumentIdentifier,
   TextEdit,
+  FoldingRange,
+  FoldingRangeKind,
 } from 'vscode-languageserver';
 import DocumentCache from '../common/document-cache.js';
 import { Position, positionToOffset } from './util/position.js';
@@ -414,6 +416,62 @@ export default class GlintLanguageServer {
   public getLanguageType(uri: string): TsUserConfigLang {
     let file = uriToFilePath(uri);
     return this.glintConfig.environment.isTypedScript(file) ? 'typescript' : 'javascript';
+  }
+
+  public getFoldingRanges(uri: string): FoldingRange[] {
+    const filePath = uriToFilePath(uri);
+    const documentContents = this.documents.getDocumentContents(filePath);
+    const spans = this.service.getOutliningSpans(filePath);
+
+    let foldingRanges = [];
+
+    for (const span of spans) {
+      const foldingRange = this.asFoldingRange(span, documentContents);
+      if (foldingRange) {
+        foldingRanges.push(foldingRange);
+      }
+    }
+
+    return foldingRanges;
+  }
+
+  private asFoldingRange(span: ts.OutliningSpan, fileContents: string): FoldingRange {
+    const start = offsetToPosition(fileContents, span.textSpan.start);
+    const end = offsetToPosition(fileContents, span.textSpan.start + span.textSpan.length);
+    const kind = this.asFoldingRangeKind(span);
+
+    // TODO: Implement this before opening a PR
+    // // workaround for https://github.com/Microsoft/vscode/issues/49904
+    // if (span.kind === 'comment') {
+    //   const line = document.getLine(range.start.line);
+    //   if (line.match(/\/\/\s*#endregion/gi)) {
+    //     return undefined;
+    //   }
+    // }
+
+    // workaround for https://github.com/Microsoft/vscode/issues/47240
+    let lastCharOfSpan = fileContents[span.textSpan.start + span.textSpan.length - 1];
+    const endLine = lastCharOfSpan === '}' ? Math.max(end.line - 1, start.line) : end.line;
+
+    return {
+      startLine: start.line,
+      endLine,
+      kind,
+    };
+  }
+
+  private asFoldingRangeKind(span: ts.OutliningSpan): FoldingRangeKind | undefined {
+    switch (span.kind) {
+      case 'comment':
+        return FoldingRangeKind.Comment;
+      case 'region':
+        return FoldingRangeKind.Region;
+      case 'imports':
+        return FoldingRangeKind.Imports;
+      case 'code':
+      default:
+        return undefined;
+    }
   }
 
   private applyCodeAction(


### PR DESCRIPTION
This adds support for code folding in js & ts files. This implementation is [based on tsserver's](https://github.com/typescript-language-server/typescript-language-server/blob/651cfcbd28992ad599b00a4ae3bc30132b2a7892/src/lsp-server.ts#L1200). This does not add support for gts/gjs files.

Folding seems to work as expected, but two odd things had to be handled:
- The OutliningSpans have TextSpans with inclusive length, leading to off-by-one errors. I handled this inline, but I'm concerned that this is unintentional and may not always be the case.
- There are some additional OutliningSpans that incorrectly have a "0" starting offset and don't match any foldable code. I believe these are retrieved from the template file and are meant to represent their folding ranges. As is, these are superfluous and cause an incorrect FoldingRange on line 1 of every component file.

Any guidance on better ways to handle either of these would be appreciated!


https://github.com/camerondubas/glint/assets/6216460/b132d090-5ebb-46bb-bd65-1dd1113d9465


